### PR TITLE
Fix http-conduit bounds

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -68,7 +68,8 @@ library
         , directory           >= 1.2
         , exceptions          >= 0.6
         , http-client         >= 0.4 && < 0.6
-        , http-conduit        >= 2.1.4 && < 3
+        -- Version 2.3 drops conduitManagerSettings
+        , http-conduit        >= 2.1.4 && < 2.3
         , ini                 >= 0.3.5
         , mmorph              >= 1
         , monad-control       >= 1

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -91,7 +91,8 @@ library
         , exceptions           >= 0.6
         , hashable             >= 1.2
         , http-client          >= 0.4 && < 0.6
-        , http-conduit         >= 2.1.4 && < 3
+        -- Version 2.3 drops conduitManagerSettings
+        , http-conduit         >= 2.1.4 && < 2.3
         , http-types           >= 0.8
         , lens                 >= 4.4
         , memory               >= 0.6


### PR DESCRIPTION
Snoyman strikes again. Version 2.3 of http-conduit drops `conduitManagerSettings`.

! @nhibberd @charleso 
/jury approved @charleso